### PR TITLE
Fix HACS repository compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Smart Dashboard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/shi_dashboard/manifest.json
+++ b/custom_components/shi_dashboard/manifest.json
@@ -2,8 +2,12 @@
   "domain": "shi_dashboard",
   "name": "SHI Dashboard",
   "version": "0.2.0",
-  "documentation": "https://github.com/user/shi_dashboard",
-  "requirements": ["pyyaml", "jinja2", "requests"],
+  "documentation": "https://github.com/user/Smart-Dashboard",
+  "requirements": [
+    "pyyaml==6.0.2",
+    "jinja2==3.1.6",
+    "requests==2.32.4"
+  ],
   "dependencies": [],
   "codeowners": []
 }

--- a/info.md
+++ b/info.md
@@ -1,0 +1,5 @@
+# SHI Dashboard
+
+Generates a Lovelace dashboard from a simple YAML configuration.
+
+See the [README](README.md) for installation and usage instructions.


### PR DESCRIPTION
## Summary
- pin dependencies in manifest
- add info.md and LICENSE
- update documentation URL in manifest

## Testing
- `python -m py_compile custom_components/shi_dashboard/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870faf096908320965b0e1452f83722