### PR TITLE
Enable UI-based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ SHI Dashboard is a customizable dashboard add-on for Home Assistant. It allows u
 Install the add-on through HACS for the simplest setup:
 1. In HACS, add `https://github.com/user/Smart-Dashboard` as a custom repository of type "integration".
 2. Search for **SHI Dashboard** and install it.
-3. Restart Home Assistant to activate the integration. On first start the integration will
-   generate a default `shi_dashboard.yaml` and `ui-lovelace.yaml` for you.
+3. Open **Settings → Devices & Services** in Home Assistant and choose **Add Integration**.
+   Select **SHI Dashboard** to complete the setup.
+4. Restart Home Assistant to generate the default `shi_dashboard.yaml` and `ui-lovelace.yaml`.
    The integration files are placed under `custom_components/shi_dashboard` in
    your Home Assistant configuration.
 

--- a/custom_components/shi_dashboard/__init__.py
+++ b/custom_components/shi_dashboard/__init__.py
@@ -7,14 +7,17 @@ import shutil
 from pathlib import Path
 
 from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from .const import DOMAIN
 
 from .dashboard import generate_dashboard
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Automatically generate config and dashboard on first install."""
+def _create_default_config(hass: HomeAssistant) -> Path:
+    """Ensure default configuration exists and return its path."""
     config_path = Path(hass.config.path("shi_dashboard.yaml"))
     if not config_path.exists():
         example = Path(__file__).parent / "config" / "example_config.yaml"
@@ -23,7 +26,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             _LOGGER.info("Created default configuration at %s", config_path)
         except OSError as err:
             _LOGGER.error("Failed to copy default config: %s", err)
+    return config_path
 
+
+def _generate_dashboard_files(hass: HomeAssistant) -> None:
+    """Generate dashboard files from configuration."""
+    config_path = _create_default_config(hass)
     output_path = Path(hass.config.path("ui-lovelace.yaml"))
     try:
         generate_dashboard(config_path, output_path)
@@ -31,7 +39,29 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     except Exception as err:  # pragma: no cover - runtime environment
         _LOGGER.error("Dashboard generation failed: %s", err)
 
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up via YAML is deprecated; create files and do nothing else."""
+    _generate_dashboard_files(hass)
     return True
 
 
-__all__ = ["generate_dashboard", "async_setup"]
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up SHI Dashboard from a config entry."""
+    _generate_dashboard_files(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = True
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return True
+
+
+__all__ = [
+    "generate_dashboard",
+    "async_setup",
+    "async_setup_entry",
+    "async_unload_entry",
+]

--- a/custom_components/shi_dashboard/config_flow.py
+++ b/custom_components/shi_dashboard/config_flow.py
@@ -1,0 +1,21 @@
+"""Config flow for SHI Dashboard integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import config_entries
+
+from .const import DOMAIN
+
+
+class ShiDashboardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for SHI Dashboard."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        """Handle the initial step."""
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title="SHI Dashboard", data={})

--- a/custom_components/shi_dashboard/const.py
+++ b/custom_components/shi_dashboard/const.py
@@ -1,0 +1,1 @@
+DOMAIN = "shi_dashboard"

--- a/custom_components/shi_dashboard/manifest.json
+++ b/custom_components/shi_dashboard/manifest.json
@@ -1,13 +1,14 @@
 {
   "domain": "shi_dashboard",
   "name": "SHI Dashboard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "documentation": "https://github.com/user/Smart-Dashboard",
   "requirements": [
     "pyyaml==6.0.2",
     "jinja2==3.1.6",
     "requests==2.32.4"
   ],
+  "config_flow": true,
   "dependencies": [],
   "codeowners": []
 }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,7 +5,9 @@ This guide explains how to install the SHI Dashboard custom integration into Hom
 ## Installing via HACS
 1. In HACS, add `https://github.com/user/Smart-Dashboard` as a custom repository of type "integration".
 2. Search for **SHI Dashboard** in HACS and install it.
-3. Restart Home Assistant to activate the integration.
+3. In Home Assistant open **Settings → Devices & Services** and click **Add Integration**.
+   Choose **SHI Dashboard** to create the configuration entry.
+4. Restart Home Assistant to activate the integration.
 
 ## Generating a Dashboard
 1. On first start, a default `shi_dashboard.yaml` configuration and `ui-lovelace.yaml`


### PR DESCRIPTION
## Summary
- add config flow and constants module
- enable config entry setup in integration init
- mark integration as supporting config flow
- document the new installation steps

## Testing
- `python3 -m compileall -q custom_components && echo done`

------
https://chatgpt.com/codex/tasks/task_e_68725276dc808320b270f44235acc577