### PR TITLE
Update dashboard location and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Install the add-on through HACS for the simplest setup:
 2. Search for **SHI Dashboard** and install it.
 3. Open **Settings → Devices & Services** in Home Assistant and choose **Add Integration**.
    Select **SHI Dashboard** to complete the setup.
-4. Restart Home Assistant to generate the default `shi_dashboard.yaml` and `ui-lovelace.yaml`.
+4. Restart Home Assistant to generate the default `shi_dashboard.yaml` and
+   `dashboards/shi_dashboard.yaml`.
    The integration files are placed under `custom_components/shi_dashboard` in
    your Home Assistant configuration.
 
@@ -19,9 +20,22 @@ See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for more details.
 
 1. Restart Home Assistant after installing the integration.
    A default configuration will be created as `shi_dashboard.yaml` and a dashboard
-   generated as `ui-lovelace.yaml`.
-2. Reload Lovelace or restart Home Assistant again to see the new dashboard.
-3. You can edit `shi_dashboard.yaml` at any time to customise the layout and run
+   generated at `dashboards/shi_dashboard.yaml`.
+2. Add the following to your `configuration.yaml` to show the dashboard
+   automatically:
+
+   ```yaml
+   lovelace:
+     dashboards:
+       shi_dashboard:
+         mode: yaml
+         title: SHI Dashboard
+         icon: mdi:monitor-dashboard
+         show_in_sidebar: true
+         filename: dashboards/shi_dashboard.yaml
+   ```
+3. Reload Lovelace or restart Home Assistant again to see the new dashboard.
+4. You can edit `shi_dashboard.yaml` at any time to customise the layout and run
    the generator manually if you wish.
 
 ## Auto Device Detection

--- a/custom_components/shi_dashboard/__init__.py
+++ b/custom_components/shi_dashboard/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
-from .const import DOMAIN
+from .const import DOMAIN, DASHBOARD_DIR, DASHBOARD_FILE
 
 from .dashboard import generate_dashboard
 
@@ -32,7 +32,9 @@ def _create_default_config(hass: HomeAssistant) -> Path:
 def _generate_dashboard_files(hass: HomeAssistant) -> None:
     """Generate dashboard files from configuration."""
     config_path = _create_default_config(hass)
-    output_path = Path(hass.config.path("ui-lovelace.yaml"))
+    output_dir = Path(hass.config.path(DASHBOARD_DIR))
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / DASHBOARD_FILE
     try:
         generate_dashboard(config_path, output_path)
         _LOGGER.info("Generated dashboard at %s", output_path)

--- a/custom_components/shi_dashboard/const.py
+++ b/custom_components/shi_dashboard/const.py
@@ -1,1 +1,3 @@
 DOMAIN = "shi_dashboard"
+DASHBOARD_DIR = "dashboards"
+DASHBOARD_FILE = "shi_dashboard.yaml"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -10,12 +10,25 @@ This guide explains how to install the SHI Dashboard custom integration into Hom
 4. Restart Home Assistant to activate the integration.
 
 ## Generating a Dashboard
-1. On first start, a default `shi_dashboard.yaml` configuration and `ui-lovelace.yaml`
-   dashboard will be created automatically.
-2. Reload Lovelace or restart Home Assistant again to see the dashboard.
+1. On first start, a default `shi_dashboard.yaml` configuration and
+   `dashboards/shi_dashboard.yaml` dashboard will be created automatically.
+2. Add this to your `configuration.yaml` so the dashboard appears in the sidebar:
+
+   ```yaml
+   lovelace:
+     dashboards:
+       shi_dashboard:
+         mode: yaml
+         title: SHI Dashboard
+         icon: mdi:monitor-dashboard
+         show_in_sidebar: true
+         filename: dashboards/shi_dashboard.yaml
+   ```
+3. Reload Lovelace or restart Home Assistant again to see the dashboard.
 3. You can modify `shi_dashboard.yaml` and run the generator manually:
    ```bash
-   python3 custom_components/shi_dashboard/dashboard.py shi_dashboard.yaml --output ui-lovelace.yaml
+   python3 custom_components/shi_dashboard/dashboard.py shi_dashboard.yaml \
+       --output dashboards/shi_dashboard.yaml
    ```
    Optionally, pass `--template <template.j2>` to use a custom Jinja2 template.
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ if [ ! -f "$CONFIG_FILE" ]; then
   echo "Created default configuration at $CONFIG_FILE"
 fi
 
-python3 custom_components/shi_dashboard/dashboard.py "$CONFIG_FILE" --output "$TARGET_DIR/ui-lovelace.yaml"
+mkdir -p "$TARGET_DIR/dashboards"
+python3 custom_components/shi_dashboard/dashboard.py "$CONFIG_FILE" --output "$TARGET_DIR/dashboards/shi_dashboard.yaml"
 echo "Installation complete. Dashboard generated."
 


### PR DESCRIPTION
## Summary
- store the generated dashboard in a `dashboards` folder
- clarify setup docs to add a `lovelace.dashboards` entry
- update install script to write to the new location

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash install.sh /tmp/ha_test`

------
https://chatgpt.com/codex/tasks/task_e_6873cda96f6c8320b392e554b5879520