### PR TITLE
Support internal API for auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for more details.
 
 ## Auto Device Detection
 
-Setting `auto_discover: true` in `shi_dashboard.yaml` will query your Home Assistant instance for all registered entities. The environment variables `HASS_URL` and `HASS_TOKEN` must be set so the generator can connect to the API. Discovered entities are grouped by their assigned area when possible, similar to Dwains Dashboard. If area information cannot be retrieved everything is placed in a single "Auto Detected" room.
+Setting `auto_discover: true` in `shi_dashboard.yaml` will query your Home Assistant instance for all registered entities. When the generator runs inside Home Assistant the API credentials are used automatically. If you run the generator manually outside of Home Assistant, set the environment variables `HASS_URL` and `HASS_TOKEN` so it can connect to the API. Discovered entities are grouped by their assigned area when possible, similar to Dwains Dashboard. If area information cannot be retrieved everything is placed in a single "Auto Detected" room.
 
 ## Plugins
 

--- a/custom_components/shi_dashboard/__init__.py
+++ b/custom_components/shi_dashboard/__init__.py
@@ -29,14 +29,16 @@ def _create_default_config(hass: HomeAssistant) -> Path:
     return config_path
 
 
-def _generate_dashboard_files(hass: HomeAssistant) -> None:
+async def _generate_dashboard_files(hass: HomeAssistant) -> None:
     """Generate dashboard files from configuration."""
     config_path = _create_default_config(hass)
     output_dir = Path(hass.config.path(DASHBOARD_DIR))
     output_dir.mkdir(exist_ok=True)
     output_path = output_dir / DASHBOARD_FILE
     try:
-        generate_dashboard(config_path, output_path)
+        await hass.async_add_executor_job(
+            generate_dashboard, config_path, output_path, None, hass
+        )
         _LOGGER.info("Generated dashboard at %s", output_path)
     except Exception as err:  # pragma: no cover - runtime environment
         _LOGGER.error("Dashboard generation failed: %s", err)
@@ -44,13 +46,13 @@ def _generate_dashboard_files(hass: HomeAssistant) -> None:
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up via YAML is deprecated; create files and do nothing else."""
-    _generate_dashboard_files(hass)
+    await _generate_dashboard_files(hass)
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SHI Dashboard from a config entry."""
-    _generate_dashboard_files(hass)
+    await _generate_dashboard_files(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = True
     return True
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -32,7 +32,7 @@ This guide explains how to install the SHI Dashboard custom integration into Hom
    ```
   Optionally, pass `--template <template.j2>` to use a custom Jinja2 template.
 
-  If `auto_discover: true` is set in the configuration, export `HASS_URL` and `HASS_TOKEN` so the generator can query Home Assistant for devices. When available, discovered entities are grouped by area to mimic Dwains Dashboard. If areas cannot be retrieved they are placed in a single "Auto Detected" room.
+  If `auto_discover: true` is set in the configuration and you run the generator outside of Home Assistant, export `HASS_URL` and `HASS_TOKEN` so it can query the API. When executed within Home Assistant the integration will automatically use its own credentials. Discovered entities are grouped by area to mimic Dwains Dashboard. If areas cannot be retrieved they are placed in a single "Auto Detected" room.
 
 ## Using Plugins
 


### PR DESCRIPTION
## Summary
- auto discovery can pull device info directly from Home Assistant without requiring HASS_TOKEN
- update installation docs and README to clarify environment variable usage

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874e338799c832097c5d31a27bf4f01