### PR TITLE
Enable auto discovery by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for more details.
 
 ## Auto Device Detection
 
-Setting `auto_discover: true` in `shi_dashboard.yaml` will query your Home Assistant instance for all registered entities. When the generator runs inside Home Assistant the API credentials are used automatically. If you run the generator manually outside of Home Assistant, set the environment variables `HASS_URL` and `HASS_TOKEN` so it can connect to the API. Discovered entities are grouped by their assigned area when possible, similar to Dwains Dashboard. If area information cannot be retrieved everything is placed in a single "Auto Detected" room.
+`auto_discover` is enabled by default and will query your Home Assistant instance for all registered entities. When the generator runs inside Home Assistant the API credentials are used automatically. If you run the generator manually outside of Home Assistant, set the environment variables `HASS_URL` and `HASS_TOKEN` so it can connect to the API. Discovered entities are grouped by their assigned area when possible, similar to Dwains Dashboard. If area information cannot be retrieved everything is placed in a single "Auto Detected" room.
 
 ## Plugins
 
@@ -52,21 +52,10 @@ markdown header card into every room.
 ## Example Configuration
 
 ```yaml
-auto_discover: false
+auto_discover: true
 layout:
   strategy: masonry
-rooms:
-  - name: Living Room
-    cards:
-      - type: thermostat
-        entity: climate.living_room
-      - type: light
-        entity: light.ceiling
-  - name: Bedroom
-    layout: horizontal
-    cards:
-      - type: light
-        entity: light.bedside
 ```
 
-This generates a dashboard with two rooms and demonstrates layout configuration. Set `auto_discover` to `true` to automatically include all detected devices.
+With auto discovery enabled the integration will query Home Assistant for all
+entities and group them by their assigned area, similar to Dwains Dashboard.

--- a/custom_components/shi_dashboard/config/example_config.yaml
+++ b/custom_components/shi_dashboard/config/example_config.yaml
@@ -1,16 +1,6 @@
-auto_discover: false
+auto_discover: true
 layout:
   strategy: masonry
-rooms:
-  - name: Living Room
-    cards:
-      - type: thermostat
-        entity: climate.living_room
-        name: HVAC
-      - type: light
-        entity: light.ceiling
-  - name: Bedroom
-    layout: horizontal
-    cards:
-      - type: light
-        entity: light.bedside
+
+# No predefined rooms are needed when auto discovery is enabled. Devices will
+# be grouped by their Home Assistant area automatically.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -32,7 +32,11 @@ This guide explains how to install the SHI Dashboard custom integration into Hom
    ```
   Optionally, pass `--template <template.j2>` to use a custom Jinja2 template.
 
-  If `auto_discover: true` is set in the configuration and you run the generator outside of Home Assistant, export `HASS_URL` and `HASS_TOKEN` so it can query the API. When executed within Home Assistant the integration will automatically use its own credentials. Discovered entities are grouped by area to mimic Dwains Dashboard. If areas cannot be retrieved they are placed in a single "Auto Detected" room.
+  Auto discovery is enabled by default. If you run the generator outside of Home Assistant,
+  export `HASS_URL` and `HASS_TOKEN` so it can query the API. When executed within Home Assistant
+  the integration will automatically use its own credentials. Discovered entities are grouped by
+  area to mimic Dwains Dashboard. If areas cannot be retrieved they are placed in a single "Auto
+  Detected" room.
 
 ## Using Plugins
 


### PR DESCRIPTION
## Summary
- default configuration now uses auto discovery
- document that discovery is enabled by default
- update install instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68752d6dba148320adf2bb9ca836c4e4