### PR TITLE
Add update script and bump integration version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The easiest way to install is through HACS:
 
 See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for more details.
 
+## Updating
+
+Run `update.sh` from the repository to download and install the latest
+version. You can also update through HACS by opening the SHI Dashboard
+integration and clicking **Update** when a new release is available.
+
 ## Getting Started
 
 1. Restart Home Assistant after installing the integration.

--- a/custom_components/shi_dashboard/manifest.json
+++ b/custom_components/shi_dashboard/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "shi_dashboard",
   "name": "SHI Dashboard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "documentation": "https://github.com/user/Smart-Dashboard",
   "requirements": [
     "pyyaml==6.0.2",

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Update script for the SHI Dashboard custom integration.
+set -euo pipefail
+
+REPO_URL="https://github.com/user/Smart-Dashboard"
+ARCHIVE_URL="$REPO_URL/archive/refs/heads/main.tar.gz"
+
+TARGET_DIR="${1:-$HOME/.homeassistant}"
+COMP_DIR="$TARGET_DIR/custom_components/shi_dashboard"
+
+echo "Downloading latest SHI Dashboard..."
+TMP_DIR=$(mktemp -d)
+curl -L "$ARCHIVE_URL" -o "$TMP_DIR/sd.tar.gz"
+tar -xzf "$TMP_DIR/sd.tar.gz" -C "$TMP_DIR"
+SRC_DIR=$(find "$TMP_DIR" -maxdepth 1 -type d -name 'Smart-Dashboard*' | head -n1)
+
+mkdir -p "$TARGET_DIR/custom_components"
+rm -rf "$COMP_DIR"
+cp -r "$SRC_DIR/custom_components/shi_dashboard" "$COMP_DIR"
+
+CONFIG_FILE="$TARGET_DIR/shi_dashboard.yaml"
+if [ ! -f "$CONFIG_FILE" ]; then
+  cp "$SRC_DIR/custom_components/shi_dashboard/config/example_config.yaml" "$CONFIG_FILE"
+  echo "Created default configuration at $CONFIG_FILE"
+fi
+
+mkdir -p "$TARGET_DIR/dashboards"
+python3 "$COMP_DIR/dashboard.py" "$CONFIG_FILE" --output "$TARGET_DIR/dashboards/shi_dashboard.yaml"
+
+echo "Update complete."
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary
- add `update.sh` helper for fetching the latest SHI Dashboard
- bump the integration version to `0.4.1`
- document how to update via script or HACS

## Testing
- `bash -n update.sh`
- `python -m py_compile custom_components/shi_dashboard/*.py`
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68764a50364c83209076fe1acf88f76d