### PR TITLE
Add config validation and example updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,25 @@ sidebar:
   - name: "\u0421\u0432\u0435\u0442"
     icon: "mdi:lightbulb"
     view: "lights"
+    condition: user == "admin"
 layout:
   strategy: masonry
 theme: auto
+rooms:
+  - name: \u0413\u043E\u0441\u0442\u0438\u043D\u0430\u044F
+    order: 1
+    cards:
+      - type: light
+        entity: light.living_room
+  - name: \u041A\u0443\u0445\u043D\u044F
+    conditions:
+      - state('binary_sensor.kitchen_motion') == 'on'
+    cards:
+      - type: light
+        entity: light.kitchen
 ```
 
 With auto discovery enabled the integration will query Home Assistant for all
 entities and group them by their assigned area, similar to Dwains Dashboard.
 Rooms can specify an `order` field to control their position in the dashboard.
+All options are validated using `voluptuous` to catch mistakes early.

--- a/custom_components/smart_dashboard/config/example_config.yaml
+++ b/custom_components/smart_dashboard/config/example_config.yaml
@@ -10,8 +10,19 @@ sidebar:
   - name: "Свет"
     icon: "mdi:lightbulb"
     view: "lights"
+    condition: user == "admin"
 layout:
   strategy: masonry
 theme: auto
-# Devices are grouped by Home Assistant area when auto discovery is enabled.
-# Rooms can specify `order` to control their position in the dashboard.
+rooms:
+  - name: Гостиная
+    order: 1
+    cards:
+      - type: light
+        entity: light.living_room
+  - name: Кухня
+    conditions:
+      - state('binary_sensor.kitchen_motion') == 'on'
+    cards:
+      - type: light
+        entity: light.kitchen

--- a/custom_components/smart_dashboard/manifest.json
+++ b/custom_components/smart_dashboard/manifest.json
@@ -8,7 +8,8 @@
   "requirements": [
     "pyyaml==6.0.2",
     "jinja2==3.1.6",
-    "requests==2.32.4"
+    "requests==2.32.4",
+    "voluptuous==0.13.1"
   ],
   "config_flow": true
 }

--- a/custom_components/smart_dashboard/schema.py
+++ b/custom_components/smart_dashboard/schema.py
@@ -1,0 +1,40 @@
+import voluptuous as vol
+
+# Card schema allows arbitrary keys so users can pass any card options
+CARD_SCHEMA = vol.Schema(
+    {vol.Required("type"): str}, extra=vol.ALLOW_EXTRA
+)
+
+ROOM_SCHEMA = vol.Schema(
+    {
+        vol.Required("name"): str,
+        vol.Optional("order"): vol.Coerce(int),
+        vol.Optional("layout"): vol.In(["horizontal", "vertical"]),
+        vol.Optional("cards", default=[]): [CARD_SCHEMA],
+        vol.Optional("conditions"): [str],
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Optional("auto_discover", default=False): bool,
+        vol.Optional("header"): {
+            vol.Required("title"): str,
+            vol.Optional("logo"): str,
+            vol.Optional("show_time", default=False): bool,
+        },
+        vol.Optional("sidebar"): [
+            {
+                vol.Required("name"): str,
+                vol.Optional("icon"): str,
+                vol.Optional("view"): str,
+                vol.Optional("condition"): str,
+            }
+        ],
+        vol.Optional("layout"): {
+            vol.Optional("strategy", default="masonry"): str
+        },
+        vol.Optional("theme", default="auto"): vol.In(["light", "dark", "auto"]),
+        vol.Optional("rooms", default=[]): [ROOM_SCHEMA],
+    }
+)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+import yaml
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import types
+
+dummy = types.ModuleType("dummy")
+sys.modules.setdefault("homeassistant", dummy)
+core_mod = types.ModuleType("core")
+core_mod.HomeAssistant = object
+sys.modules.setdefault("homeassistant.core", core_mod)
+sys.modules.setdefault("homeassistant.helpers", types.ModuleType("helpers"))
+helpers_mod = sys.modules["homeassistant.helpers"]
+helpers_mod.area_registry = types.ModuleType("area_registry")
+helpers_mod.device_registry = types.ModuleType("device_registry")
+helpers_mod.entity_registry = types.ModuleType("entity_registry")
+sys.modules.setdefault("homeassistant.helpers.area_registry", helpers_mod.area_registry)
+sys.modules.setdefault("homeassistant.helpers.device_registry", helpers_mod.device_registry)
+sys.modules.setdefault("homeassistant.helpers.entity_registry", helpers_mod.entity_registry)
+sys.modules.setdefault("homeassistant.config_entries", types.ModuleType("config_entries"))
+sys.modules["homeassistant.config_entries"].ConfigEntry = object
+
+from custom_components.smart_dashboard.dashboard import load_config
+
+
+def test_load_valid_config(tmp_path):
+    cfg = {"rooms": [{"name": "Living", "cards": [{"type": "light"}]}]}
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    data = load_config(path)
+    assert data["rooms"][0]["name"] == "Living"
+
+
+def test_load_invalid_config(tmp_path):
+    cfg = {"rooms": [{"name": 123}]}
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    with pytest.raises(ValueError):
+        load_config(path)


### PR DESCRIPTION
## Summary
- add voluptuous config schema and validation
- update example configuration and README with advanced options
- require `voluptuous` in manifest
- unit test configuration loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687652c8139c8320a5a4ea802accb19c