### PR TITLE
Implement Lovelace card loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ The `blueprint_loader` plugin loads any YAML files found in
 rooms. This mimics the blueprint system in Dwains Dashboard for quickly adding
 predefined layouts.
 
+`lovelace_cards_loader` can import existing Lovelace views by talking to the
+Home Assistant API. Enable it by setting `load_lovelace_cards: true` in your
+configuration. The generator will request `/api/lovelace` using the credentials
+provided via the `HASS_URL` and `HASS_TOKEN` environment variables and append
+the returned views as rooms.
+
 Translation files located under `custom_components/smart_dashboard/translations`
 allow the dashboard to be generated in different languages. Set the `SHI_LANG`
 environment variable (e.g. `en`, `ru`, `bg`, or `es`) to select the language. If no
@@ -91,6 +97,7 @@ sidebar:
 layout:
   strategy: masonry
 theme: auto
+load_lovelace_cards: true
 rooms:
   - name: \u0413\u043E\u0441\u0442\u0438\u043D\u0430\u044F
     order: 1

--- a/custom_components/smart_dashboard/plugins/lovelace_cards_loader.py
+++ b/custom_components/smart_dashboard/plugins/lovelace_cards_loader.py
@@ -1,0 +1,45 @@
+"""Load Lovelace cards from Home Assistant via its API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def process_config(config: Dict[str, Any]) -> None:
+    """Append rooms generated from the current Lovelace config."""
+    if not config.get("load_lovelace_cards"):
+        return
+
+    token = os.environ.get("HASS_TOKEN")
+    if not token:
+        _LOGGER.error("load_lovelace_cards enabled but HASS_TOKEN is not set")
+        return
+
+    hass_url = os.environ.get("HASS_URL", "http://localhost:8123").rstrip("/")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        resp = requests.get(f"{hass_url}/api/lovelace", headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as err:  # pragma: no cover - runtime environment
+        _LOGGER.error("Failed to load Lovelace config: %s", err)
+        return
+
+    views = data.get("views", data.get("data", {}).get("views", []))
+    rooms = config.setdefault("rooms", [])
+    for idx, view in enumerate(views, 1):
+        rooms.append(
+            {
+                "name": view.get("title", f"View {idx}"),
+                "order": idx,
+                "cards": view.get("cards", []),
+            }
+        )
+

--- a/custom_components/smart_dashboard/schema.py
+++ b/custom_components/smart_dashboard/schema.py
@@ -35,6 +35,7 @@ CONFIG_SCHEMA = vol.Schema(
             vol.Optional("strategy", default="masonry"): str
         },
         vol.Optional("theme", default="auto"): vol.In(["light", "dark", "auto"]),
+        vol.Optional("load_lovelace_cards", default=False): bool,
         vol.Optional("rooms", default=[]): [ROOM_SCHEMA],
     }
 )

--- a/tests/test_lovelace_loader.py
+++ b/tests/test_lovelace_loader.py
@@ -1,0 +1,33 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from custom_components.smart_dashboard.plugins.lovelace_cards_loader import process_config
+
+
+def test_loader(monkeypatch):
+    data = {"views": [{"title": "API View", "cards": [{"type": "light"}]}]}
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return data
+
+    def fake_get(url, headers=None, timeout=10):
+        assert url.endswith("/api/lovelace")
+        return FakeResp()
+
+    monkeypatch.setattr(
+        "custom_components.smart_dashboard.plugins.lovelace_cards_loader.requests.get",
+        fake_get,
+    )
+    monkeypatch.setenv("HASS_TOKEN", "abc")
+    monkeypatch.setenv("HASS_URL", "http://localhost")
+    cfg = {"load_lovelace_cards": True}
+    process_config(cfg)
+    assert cfg["rooms"][0]["name"] == "API View"
+    assert cfg["rooms"][0]["cards"][0]["type"] == "light"


### PR DESCRIPTION
## Summary
- allow enabling dynamic loading of Lovelace cards via new `load_lovelace_cards` option
- document new feature and option in README
- add plugin `lovelace_cards_loader` that pulls existing views through `/api/lovelace`
- test the loader plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687656db147083208847becf013d92dc