### PR TITLE
Add conditions to config flow

### DIFF
--- a/custom_components/smart_dashboard/config_flow.py
+++ b/custom_components/smart_dashboard/config_flow.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import voluptuous as vol
+
 from homeassistant import config_entries
 
 from .const import DOMAIN
@@ -18,4 +20,15 @@ class SmartDashboardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
-        return self.async_create_entry(title="Smart Dashboard", data={})
+
+        if user_input is not None:
+            cond_text = user_input.get("conditions", "").strip()
+            conditions = [c.strip() for c in cond_text.splitlines() if c.strip()]
+            return self.async_create_entry(
+                title="Smart Dashboard", data={"conditions": conditions}
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Optional("conditions"): str}),
+        )


### PR DESCRIPTION
## Summary
- extend Smart Dashboard config flow with optional condition entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765891ce008320973463fffffa3d45