### PR TITLE
Add JS helper for dynamic state updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,28 @@ With auto discovery enabled the integration will query Home Assistant for all
 entities and group them by their assigned area, similar to Dwains Dashboard.
 Rooms can specify an `order` field to control their position in the dashboard.
 All options are validated using `voluptuous` to catch mistakes early.
+
+## Web Client
+
+A small JavaScript helper is available at `custom_components/smart_dashboard/www/main.js`.
+Include it as a Lovelace resource to enable live updates. The script periodically
+fetches entity states from the Home Assistant REST API and fills any element with
+a `data-entity-id` attribute with the current state.
+
+Example resource declaration:
+
+```yaml
+resources:
+  - url: /local/smart_dashboard/main.js
+    type: module
+```
+
+Usage inside a dashboard:
+
+```html
+<span data-entity-id="sensor.outside_temperature"></span>
+<script>
+  const sd = new window.SmartDashboard('http://homeassistant.local:8123', 'YOUR_LONG_LIVED_TOKEN');
+  sd.start();
+</script>
+```

--- a/custom_components/smart_dashboard/www/main.js
+++ b/custom_components/smart_dashboard/www/main.js
@@ -1,0 +1,43 @@
+class SmartDashboard {
+  constructor(url, token) {
+    this.url = url.replace(/\/$/, '');
+    this.token = token;
+    this.state = [];
+    this.interval = null;
+  }
+
+  async fetchStates() {
+    try {
+      const resp = await fetch(`${this.url}/api/states`, {
+        headers: { 'Authorization': `Bearer ${this.token}` }
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      this.state = await resp.json();
+      this.updateDom();
+    } catch(err) {
+      console.error('Failed loading states:', err);
+    }
+  }
+
+  updateDom() {
+    document.querySelectorAll('[data-entity-id]').forEach(el => {
+      const entity = el.dataset.entityId;
+      const st = this.state.find(s => s.entity_id === entity);
+      if (st) {
+        el.textContent = st.state;
+      }
+    });
+  }
+
+  start(interval = 5000) {
+    this.fetchStates();
+    this.interval = setInterval(() => this.fetchStates(), interval);
+  }
+
+  stop() {
+    if (this.interval) clearInterval(this.interval);
+  }
+}
+
+window.SmartDashboard = SmartDashboard;
+


### PR DESCRIPTION
## Summary
- provide a simple JS file that polls the HA REST API and updates elements with `data-entity-id`
- document how to use the script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687678f0fa548320b18efbb75bec740f