### PR TITLE
Enable Lovelace card embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ rooms:
     cards:
       - type: light
         entity: light.living_room
+      - type: glance
+        entities:
+          - sensor.temperature
+          - binary_sensor.front_door
   - name: \u041A\u0443\u0445\u043D\u044F
     conditions:
       - state('binary_sensor.kitchen_motion') == 'on'
@@ -116,6 +120,9 @@ With auto discovery enabled the integration will query Home Assistant for all
 entities and group them by their assigned area, similar to Dwains Dashboard.
 Rooms can specify an `order` field to control their position in the dashboard.
 All options are validated using `voluptuous` to catch mistakes early.
+You can embed any standard Lovelace card by listing its configuration under
+`cards`. For example `type: glance` or `type: light` entries are passed through
+to the generated dashboard unchanged.
 
 ## Web Client
 

--- a/custom_components/smart_dashboard/config/example_config.yaml
+++ b/custom_components/smart_dashboard/config/example_config.yaml
@@ -20,6 +20,10 @@ rooms:
     cards:
       - type: light
         entity: light.living_room
+      - type: glance
+        entities:
+          - sensor.temperature
+          - binary_sensor.front_door
   - name: Кухня
     conditions:
       - state('binary_sensor.kitchen_motion') == 'on'

--- a/custom_components/smart_dashboard/schema.py
+++ b/custom_components/smart_dashboard/schema.py
@@ -12,7 +12,8 @@ ROOM_SCHEMA = vol.Schema(
         vol.Optional("layout"): vol.In(["horizontal", "vertical"]),
         vol.Optional("cards", default=[]): [CARD_SCHEMA],
         vol.Optional("conditions"): [str],
-    }
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 CONFIG_SCHEMA = vol.Schema(


### PR DESCRIPTION
## Summary
- relax room schema so unknown view options are allowed
- show how to embed Lovelace cards in README
- update example config with a glance card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767e115aa4832080c1cc14c8622bc9