### PR TITLE
Add area/device grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install homeassistant pyyaml jinja2 requests
 
 ## Auto Device Detection
 
-`auto_discover` is enabled by default and will query your Home Assistant instance for all registered entities. When the generator runs inside Home Assistant it uses the integration's credentials automatically. If you run the generator manually outside of Home Assistant **you must set the environment variables** `HASS_URL` and `HASS_TOKEN` so it can connect to the API. Discovered entities are grouped by their assigned area when possible; if area information cannot be retrieved everything is placed in a single "Auto Detected" room.
+`auto_discover` is enabled by default and will query your Home Assistant instance for all registered entities. When the generator runs inside Home Assistant it uses the integration's credentials automatically. If you run the generator manually outside of Home Assistant **you must set the environment variables** `HASS_URL` and `HASS_TOKEN` so it can connect to the API. Discovered entities are grouped by their assigned area when possible; if area information cannot be retrieved everything is placed in a single "Auto Detected" room. Devices within an area are further arranged into stacks of lights, climate controls and multimedia players.
 
 ## Plugins
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -43,7 +43,8 @@ dashboard.
    to set `HASS_URL` and `HASS_TOKEN` so the generator can query the API. When
    executed within Home Assistant it automatically uses its own credentials.
 Entities are grouped by area when possible; if no areas are available they are
-placed in a single "Auto Detected" room.
+placed in a single "Auto Detected" room. Within each area the devices are
+organized into light, climate and multimedia sections to create a cleaner layout.
 
 Set the `SHI_LANG` environment variable (for example `en`, `ru`, `bg`, or `es`) to
 generate the dashboard in a different language.

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from custom_components.smart_dashboard.dashboard import _group_cards_by_type
+
+
+def test_grouping():
+    cards = [
+        {"type": "light", "entity": "light.l1"},
+        {"type": "thermostat", "entity": "climate.c1"},
+        {"type": "media-control", "entity": "media_player.m1"},
+        {"type": "sensor", "entity": "sensor.temp"},
+    ]
+    grouped = _group_cards_by_type(cards)
+    assert grouped[0]["type"] == "vertical-stack"
+    assert len(grouped[0]["cards"]) == 1
+    assert grouped[1]["type"] == "vertical-stack"
+    assert len(grouped[1]["cards"]) == 1
+    assert grouped[2]["type"] == "vertical-stack"
+    assert len(grouped[2]["cards"]) == 1
+    assert grouped[3]["type"] == "sensor"


### PR DESCRIPTION
## Summary
- group auto-discovered devices by type using `_group_cards_by_type`
- document grouping behaviour in README and installation guide
- test new grouping helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687680301af88320b09c639832884188