### PR TITLE
Add options flow for Smart Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The easiest way to install is through HACS:
    Select **Smart Dashboard** to create the configuration entry.
 4. Restart Home Assistant. This generates `smart_dashboard.yaml` and `dashboards/smart_dashboard.yaml`.
    The integration files live under `custom_components/smart_dashboard` in your configuration directory.
+5. The integration provides a `config_flow` declared in `manifest.json`, so it shows up automatically in the **Add Integration** dialog.
 
 See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for more details.
 

--- a/custom_components/smart_dashboard/config_flow.py
+++ b/custom_components/smart_dashboard/config_flow.py
@@ -7,6 +7,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.core import callback
 
 from .const import DOMAIN
 
@@ -31,4 +32,32 @@ class SmartDashboardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({vol.Optional("conditions"): str}),
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(entry: config_entries.ConfigEntry):
+        """Return the options flow handler."""
+        return SmartDashboardOptionsFlowHandler(entry)
+
+
+class SmartDashboardOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options for Smart Dashboard."""
+
+    def __init__(self, entry: config_entries.ConfigEntry) -> None:
+        self.entry = entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        """Manage options for Smart Dashboard."""
+        if user_input is not None:
+            cond_text = user_input.get("conditions", "").strip()
+            conditions = [c.strip() for c in cond_text.splitlines() if c.strip()]
+            return self.async_create_entry(data={"conditions": conditions})
+
+        cond_text = "\n".join(self.entry.data.get("conditions", []))
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Optional("conditions", default=cond_text): str
+            }),
         )

--- a/custom_components/smart_dashboard/translations/bg.json
+++ b/custom_components/smart_dashboard/translations/bg.json
@@ -1,4 +1,23 @@
 {
   "auto_detected": "Автоматично открити",
-  "room": "Стая"
+  "room": "Стая",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "conditions": "Глобални условия (по едно на ред)"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Настройки Smart Dashboard",
+        "data": {
+          "conditions": "Глобални условия (по едно на ред)"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/smart_dashboard/translations/en.json
+++ b/custom_components/smart_dashboard/translations/en.json
@@ -1,4 +1,23 @@
 {
   "auto_detected": "Auto Detected",
-  "room": "Room"
+  "room": "Room",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "conditions": "Global conditions (one per line)"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Smart Dashboard Options",
+        "data": {
+          "conditions": "Global conditions (one per line)"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/smart_dashboard/translations/es.json
+++ b/custom_components/smart_dashboard/translations/es.json
@@ -1,4 +1,23 @@
 {
   "auto_detected": "Detectado automáticamente",
-  "room": "Habitación"
+  "room": "Habitación",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "conditions": "Condiciones globales (una por línea)"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de Smart Dashboard",
+        "data": {
+          "conditions": "Condiciones globales (una por línea)"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/smart_dashboard/translations/fr.json
+++ b/custom_components/smart_dashboard/translations/fr.json
@@ -1,4 +1,23 @@
 {
   "auto_detected": "Détecté automatiquement",
-  "room": "Pièce"
+  "room": "Pièce",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "conditions": "Conditions globales (une par ligne)"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options Smart Dashboard",
+        "data": {
+          "conditions": "Conditions globales (une par ligne)"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/smart_dashboard/translations/ru.json
+++ b/custom_components/smart_dashboard/translations/ru.json
@@ -1,4 +1,23 @@
 {
   "auto_detected": "Авто обнаружение",
-  "room": "Комната"
+  "room": "Комната",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "conditions": "Глобальные условия (по одному на строку)"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Параметры Smart Dashboard",
+        "data": {
+          "conditions": "Глобальные условия (по одному на строку)"
+        }
+      }
+    }
+  }
 }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,6 +8,7 @@ Follow these steps to install the Smart Dashboard custom integration into Home A
 3. Open **Settings → Devices & Services** in Home Assistant and click **Add Integration**.
    Choose **Smart Dashboard** to create the configuration entry.
 4. Restart Home Assistant to activate the integration.
+   Since `manifest.json` enables a `config_flow`, Smart Dashboard appears automatically in the **Add Integration** list.
 
 ## Generate Your First Dashboard
 1. The first start creates `smart_dashboard.yaml` and `dashboards/smart_dashboard.yaml` automatically.


### PR DESCRIPTION
## Summary
- implement options flow to edit conditions
- update translations for config/option dialogs
- document automatic integration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687688d2bc748320af23e2d2b07ec462