### PR TITLE
Fix translation file I/O in Smart Dashboard

### DIFF
--- a/custom_components/smart_dashboard/dashboard.py
+++ b/custom_components/smart_dashboard/dashboard.py
@@ -41,20 +41,8 @@ logger = logging.getLogger(__name__)
 _TRANSLATIONS: Dict[str, Dict[str, str]] = {}
 
 
-def _load_all_translations() -> None:
-    """Pre-load all translations from the translations folder."""
-    trans_dir = Path(__file__).parent / "translations"
-    for path in trans_dir.glob("*.json"):
-        lang = path.stem
-        try:
-            with path.open() as f:
-                _TRANSLATIONS[lang] = json.load(f)
-        except Exception:  # pragma: no cover - runtime environment
-            _TRANSLATIONS[lang] = {}
-
-
-# Load translations at import time to avoid file I/O in the event loop
-_load_all_translations()
+# Translations are loaded lazily by ``load_translations`` to avoid blocking I/O
+# during import when the Home Assistant event loop is already running.
 
 
 async def load_translations(lang: str) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- avoid preloading translation files during import
- use lazy loading so file access occurs in a background thread

## Testing
- `pip install pyyaml==6.0.2 jinja2==3.1.6 requests==2.32.4 voluptuous==0.13.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687699843d648320b9a41b8c022a72b5