### PR TITLE
Fix voluptuous version conflict

### DIFF
--- a/custom_components/smart_dashboard/manifest.json
+++ b/custom_components/smart_dashboard/manifest.json
@@ -9,7 +9,7 @@
     "pyyaml==6.0.2",
     "jinja2==3.1.6",
     "requests==2.32.4",
-    "voluptuous==0.13.1"
+    "voluptuous==0.15.2"
   ],
   "config_flow": true
 }


### PR DESCRIPTION
## Summary
- bump voluptuous requirement to 0.15.2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769b8c286483208356255b9eb39fde