### PR TITLE
Add devices overview view

### DIFF
--- a/custom_components/smart_dashboard/dashboard.py
+++ b/custom_components/smart_dashboard/dashboard.py
@@ -313,6 +313,20 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
             "cards": overview_cards,
         })
 
+    # Device overview showing all cards grouped by type
+    device_cards: List[Dict[str, Any]] = []
+    for room in rooms:
+        if room.get("hidden"):
+            continue
+        device_cards.extend(room.get("cards", []))
+    grouped_devices = _group_cards_by_type(device_cards)
+    if grouped_devices:
+        views.append({
+            "title": asyncio.run(t("devices", lang, "Devices")),
+            "path": "devices",
+            "cards": grouped_devices,
+        })
+
     for room in rooms:
         if room.get("hidden"):
             continue

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,6 +15,7 @@ def test_overview_generation():
     }
     dash = build_dashboard(cfg, "en")
     assert dash["views"][0]["title"] == "Overview"
+    assert dash["views"][1]["title"] == "Devices"
     assert dash["views"][0]["cards"][0]["tap_action"]["navigation_path"] == "/lovelace/living-room"
-    assert dash["views"][1]["path"] == "living-room"
-    assert dash["views"][2]["path"] == "kitchen"
+    assert dash["views"][2]["path"] == "living-room"
+    assert dash["views"][3]["path"] == "kitchen"


### PR DESCRIPTION
## Summary
- group all room cards together to build a `Devices` overview
- test that new view is created

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a4c9c5a08320a29814cb133bc363