### PR TITLE
Add Dwains-style JS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ predefined layouts.
 
 The `dwains_style` plugin creates a Dwains Dashboard inspired navigation bar. It
 automatically adds each room as a sidebar shortcut, enables the clock in the
-header and applies a default `dwains` theme.
+header and applies a default `dwains` theme. It also loads a small JavaScript
+module that draws a live clock in the header so the dashboard feels closer to
+Dwains Dashboard. The script is served from `/local/dwains_style.js` and is
+added automatically to the Lovelace `resources` section.
 
 `lovelace_cards_loader` can import existing Lovelace views by talking to the
 Home Assistant API. Enable it by setting `load_lovelace_cards: true` in your

--- a/custom_components/smart_dashboard/dashboard.py
+++ b/custom_components/smart_dashboard/dashboard.py
@@ -351,6 +351,8 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
         dashboard["header"] = config["header"]
     if "sidebar" in config:
         dashboard["sidebar"] = config["sidebar"]
+    if "resources" in config:
+        dashboard["resources"] = config["resources"]
     return dashboard
 
 

--- a/custom_components/smart_dashboard/plugins/dwains_style.py
+++ b/custom_components/smart_dashboard/plugins/dwains_style.py
@@ -30,3 +30,8 @@ def process_config(config: Dict[str, Any]) -> None:
             continue
         sidebar.append({"name": name, "icon": "mdi:chevron-right", "view": view})
         existing.add(view)
+
+    resources = config.setdefault("resources", [])
+    urls = {res.get("url") for res in resources if isinstance(res, dict)}
+    if "/local/dwains_style.js" not in urls:
+        resources.append({"url": "/local/dwains_style.js", "type": "module"})

--- a/custom_components/smart_dashboard/schema.py
+++ b/custom_components/smart_dashboard/schema.py
@@ -38,6 +38,12 @@ CONFIG_SCHEMA = vol.Schema(
         },
         vol.Optional("theme", default="auto"): vol.In(["light", "dark", "auto"]),
         vol.Optional("load_lovelace_cards", default=False): bool,
+        vol.Optional("resources", default=[]): [
+            {
+                vol.Required("url"): str,
+                vol.Required("type"): str,
+            }
+        ],
         vol.Optional("rooms", default=[]): [ROOM_SCHEMA],
     }
 )

--- a/custom_components/smart_dashboard/www/dwains_style.js
+++ b/custom_components/smart_dashboard/www/dwains_style.js
@@ -1,0 +1,26 @@
+class DwainsStyle {
+  constructor() {
+    document.addEventListener('DOMContentLoaded', () => {
+      const header = document.querySelector('ha-header-bar');
+      if (header) {
+        this.addClock(header);
+      }
+    });
+  }
+
+  addClock(header) {
+    const clock = document.createElement('div');
+    clock.id = 'dwains-clock';
+    clock.style.marginLeft = 'auto';
+    clock.style.padding = '0 16px';
+    clock.style.fontWeight = 'bold';
+    header.appendChild(clock);
+    const update = () => {
+      const now = new Date();
+      clock.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    };
+    update();
+    setInterval(update, 60000);
+  }
+}
+new DwainsStyle();

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,10 @@ echo "Installing Smart Dashboard to $COMP_DIR"
 mkdir -p "$TARGET_DIR/custom_components"
 cp -r custom_components/smart_dashboard "$COMP_DIR"
 
+# Copy JavaScript UI helpers
+mkdir -p "$TARGET_DIR/www"
+cp custom_components/smart_dashboard/www/dwains_style.js "$TARGET_DIR/www/dwains_style.js"
+
 CONFIG_FILE="$TARGET_DIR/smart_dashboard.yaml"
 if [ ! -f "$CONFIG_FILE" ]; then
   cp custom_components/smart_dashboard/config/example_config.yaml "$CONFIG_FILE"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -19,3 +19,18 @@ def test_overview_generation():
     assert dash["views"][0]["cards"][0]["tap_action"]["navigation_path"] == "/lovelace/living-room"
     assert dash["views"][2]["path"] == "living-room"
     assert dash["views"][3]["path"] == "kitchen"
+
+
+def test_resources_included():
+    cfg = {
+        "resources": [{"url": "/local/test.js", "type": "module"}],
+        "rooms": [],
+    }
+    dash = build_dashboard(cfg, "en")
+    assert dash["resources"][0]["url"] == "/local/test.js"
+
+def test_dwains_plugin_resources():
+    from custom_components.smart_dashboard.plugins.dwains_style import process_config
+    cfg = {"rooms": [{"name": "Room"}]}
+    process_config(cfg)
+    assert any(r.get("url") == "/local/dwains_style.js" for r in cfg.get("resources", []))

--- a/update.sh
+++ b/update.sh
@@ -18,6 +18,10 @@ mkdir -p "$TARGET_DIR/custom_components"
 rm -rf "$COMP_DIR"
 cp -r "$SRC_DIR/custom_components/smart_dashboard" "$COMP_DIR"
 
+# Copy JavaScript UI helpers
+mkdir -p "$TARGET_DIR/www"
+cp "$SRC_DIR/custom_components/smart_dashboard/www/dwains_style.js" "$TARGET_DIR/www/dwains_style.js"
+
 CONFIG_FILE="$TARGET_DIR/smart_dashboard.yaml"
 if [ ! -f "$CONFIG_FILE" ]; then
   cp "$SRC_DIR/custom_components/smart_dashboard/config/example_config.yaml" "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- extend config schema with `resources` list
- include resources when building the dashboard
- enhance `dwains_style` plugin to inject `/local/dwains_style.js`
- ship new `dwains_style.js` that draws a clock in the header
- copy JS during install/update
- document new behaviour
- add tests for resources handling and plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a9b1ada48320a08736dc39aa4845