### PR TITLE
Fix duplicate cards and deduplicate entities

### DIFF
--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from custom_components.smart_dashboard.dashboard import deduplicate_cards
+
+
+def test_remove_duplicate_cards():
+    cfg = {"rooms": [{"name": "Room", "cards": [
+        {"type": "light", "entity": "light.l1"},
+        {"type": "light", "entity": "light.l1"},
+        {"type": "light", "entity": "light.l2"},
+    ]}]}
+    deduplicate_cards(cfg)
+    cards = cfg["rooms"][0]["cards"]
+    assert len(cards) == 2
+    assert {c["entity"] for c in cards} == {"light.l1", "light.l2"}

--- a/tests/test_discover_dedup.py
+++ b/tests/test_discover_dedup.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from custom_components.smart_dashboard.dashboard import discover_devices
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+
+def test_discover_devices_deduplicates(monkeypatch):
+    states = [
+        {"entity_id": "light.a"},
+        {"entity_id": "light.a"},  # duplicate
+        {"entity_id": "light.b"},
+    ]
+
+    def fake_get(url, headers=None, timeout=10):
+        if url.endswith('/api/states'):
+            return FakeResp(states)
+        elif url.endswith('/api/areas'):
+            return FakeResp([])
+        elif url.endswith('/api/devices'):
+            return FakeResp([])
+        elif url.endswith('/api/entities'):
+            return FakeResp([])
+        raise AssertionError('unexpected url ' + url)
+
+    monkeypatch.setattr('custom_components.smart_dashboard.dashboard.requests.get', fake_get)
+    rooms = discover_devices('http://localhost', 'abc', 'en')
+    cards = rooms[0]['cards']
+    entities = set()
+    for card in cards:
+        if 'cards' in card:
+            for c in card['cards']:
+                entities.add(c['entity'])
+        else:
+            entities.add(card['entity'])
+    assert entities == {'light.a', 'light.b'}


### PR DESCRIPTION
## Summary
- deduplicate entity list when discovering devices
- add `deduplicate_cards` helper and run it during generation
- test deduplication logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cda47f00832087927a5cb68f9560