### PR TITLE
Add device previews to area navigation

### DIFF
--- a/custom_components/smart_dashboard/dashboard.py
+++ b/custom_components/smart_dashboard/dashboard.py
@@ -395,16 +395,32 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
         active_count = sum(
             1 for card in room.get("cards", []) if isinstance(card, dict) and card.get("entity")
         )
-        overview_cards.append({
-            "type": "custom:button-card",
-            "icon": icon,
-            "name": name,
-            "label": f"{active_count} devices",
-            "tap_action": {
-                "action": "navigate",
-                "navigation_path": f"/lovelace/{path}",
-            },
-        })
+        tile_cards = _apply_tile_templates(room.get("cards", []))[:4]
+        stack = {
+            "type": "vertical-stack",
+            "cards": [
+                {
+                    "type": "custom:button-card",
+                    "icon": icon,
+                    "name": name,
+                    "label": f"{active_count} devices",
+                    "tap_action": {
+                        "action": "navigate",
+                        "navigation_path": f"/lovelace/{path}",
+                    },
+                }
+            ],
+        }
+        if tile_cards:
+            stack["cards"].append(
+                {
+                    "type": "grid",
+                    "columns": 2,
+                    "square": False,
+                    "cards": tile_cards,
+                }
+            )
+        overview_cards.append(stack)
 
     if overview_cards:
         views.append({

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -18,9 +18,14 @@ def test_overview_generation():
     assert dash["views"][1]["title"] == "Devices"
     grid = dash["views"][0]["cards"][0]
     assert grid["type"] == "grid"
-    first = grid["cards"][0]
-    assert first["tap_action"]["navigation_path"] == "/lovelace/living-room"
-    assert first["type"] == "custom:button-card"
+    stack = grid["cards"][0]
+    assert stack["type"] == "vertical-stack"
+    btn = stack["cards"][0]
+    assert btn["tap_action"]["navigation_path"] == "/lovelace/living-room"
+    assert btn["type"] == "custom:button-card"
+    # Next card shows device tiles
+    grid_inside = stack["cards"][1]
+    assert grid_inside["type"] == "grid"
     # Devices view is a grid of stacks
     device_grid = dash["views"][1]["cards"][0]
     assert device_grid["type"] == "grid"


### PR DESCRIPTION
## Summary
- show devices inside area buttons
- update dashboard unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687778c2ca848320ba3b600fa3ae0ccc