### PR TITLE
docs: mention avoiding duplicate cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ pip install homeassistant pyyaml jinja2 requests
 `auto_discover` is enabled by default and will query your Home Assistant instance for all registered entities. When the generator runs inside Home Assistant it uses the integration's credentials automatically. If you run the generator manually outside of Home Assistant **you must set the environment variables** `HASS_URL` and `HASS_TOKEN` so it can connect to the API. Discovered entities are grouped by their assigned area when possible; if area information cannot be retrieved everything is placed in a single "Auto Detected" room. Devices within an area are further arranged into stacks of lights, climate controls, multimedia players and sensors.
 If the API cannot be reached the generator logs a warning and automatically disables `auto_discover` so you can provide entity IDs manually.
 
+When mixing auto discovery with your own rooms it is possible to end up with duplicate cards.  You can hide the automatically generated "Auto Detected" room by adding `hidden: true` to that room entry in your configuration.  Alternatively disable discovery for devices you do not want by removing their domains from the generated configuration or turning `auto_discover` off entirely after copying the desired cards.
+
 ## Plugins
 
 Plugins placed in `custom_components/smart_dashboard/plugins` can modify the

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -40,6 +40,7 @@ dashboard.
 Entities are grouped by area when possible; if no areas are available they are
 placed in a single "Auto Detected" room. Within each area the devices are
 organized into light, climate, multimedia and sensor sections to create a cleaner layout.
+If you notice duplicate cards after customizing rooms, mark the generated "Auto Detected" room with `hidden: true` or remove domains you do not need from the configuration.
 
 Set the `SHI_LANG` environment variable (for example `en`, `ru`, `bg`, or `es`) to
 generate the dashboard in a different language.


### PR DESCRIPTION
## Summary
- document how to hide or disable auto-discovered cards when mixing them with manual configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ac7ade688320b085fa898747bc87