### PR TITLE
Add configurable overview device limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,16 @@ sidebar:
 layout:
   strategy: masonry
 theme: auto
+overview_limit: 4
 load_lovelace_cards: true
 ```
 
 With auto discovery enabled the integration will query Home Assistant for all
 entities and group them by their assigned area, similar to Dwains Dashboard.
 Rooms can specify an `order` field to control their position in the dashboard.
+Use `overview_limit` to adjust how many device tiles each room shows on the
+overview page. Set it globally or per room to override the default of four
+tiles.
 All options are validated using `voluptuous` to catch mistakes early.
 You can embed any standard Lovelace card by listing its configuration under
 `cards`. For example `type: glance` or `type: light` entries are passed through

--- a/custom_components/smart_dashboard/config/example_config.yaml
+++ b/custom_components/smart_dashboard/config/example_config.yaml
@@ -14,6 +14,7 @@ sidebar:
 layout:
   strategy: masonry
 theme: auto
+overview_limit: 4
 button_card_templates:
   device_tile:
     show_icon: true

--- a/custom_components/smart_dashboard/const.py
+++ b/custom_components/smart_dashboard/const.py
@@ -1,3 +1,4 @@
 DOMAIN = "smart_dashboard"
 DASHBOARD_DIR = "dashboards"
 DASHBOARD_FILE = "smart_dashboard.yaml"
+DEFAULT_OVERVIEW_LIMIT = 4

--- a/custom_components/smart_dashboard/dashboard.py
+++ b/custom_components/smart_dashboard/dashboard.py
@@ -15,6 +15,7 @@ import logging
 import sys
 import json
 from homeassistant.core import HomeAssistant
+from .const import DEFAULT_OVERVIEW_LIMIT
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
@@ -426,6 +427,7 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
         config.get("rooms", []),
         key=lambda r: r.get("order", 0)
     )
+    global_limit = int(config.get("overview_limit", DEFAULT_OVERVIEW_LIMIT))
 
     overview_cards = []
     for room in rooms:
@@ -437,7 +439,8 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
         active_count = sum(
             1 for card in room.get("cards", []) if isinstance(card, dict) and card.get("entity")
         )
-        tile_cards = _apply_tile_templates(room.get("cards", []))[:4]
+        room_limit = int(room.get("overview_limit", global_limit))
+        tile_cards = _apply_tile_templates(room.get("cards", []))[:room_limit]
         stack = {
             "type": "vertical-stack",
             "cards": [

--- a/custom_components/smart_dashboard/schema.py
+++ b/custom_components/smart_dashboard/schema.py
@@ -1,4 +1,5 @@
 import voluptuous as vol
+from .const import DEFAULT_OVERVIEW_LIMIT
 
 # Card schema allows arbitrary keys so users can pass any card options
 CARD_SCHEMA = vol.Schema(
@@ -11,6 +12,7 @@ ROOM_SCHEMA = vol.Schema(
         vol.Optional("icon"): str,
         vol.Optional("order"): vol.Coerce(int),
         vol.Optional("layout"): vol.In(["horizontal", "vertical"]),
+        vol.Optional("overview_limit"): vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional("cards", default=[]): [CARD_SCHEMA],
         vol.Optional("conditions"): [str],
         vol.Optional("hidden", default=False): bool,
@@ -38,6 +40,7 @@ CONFIG_SCHEMA = vol.Schema(
             vol.Optional("strategy", default="masonry"): str
         },
         vol.Optional("theme", default="auto"): vol.In(["light", "dark", "auto"]),
+        vol.Optional("overview_limit", default=DEFAULT_OVERVIEW_LIMIT): vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional("load_lovelace_cards", default=False): bool,
         vol.Optional("resources", default=[]): [
             {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -58,3 +58,41 @@ def test_empty_room_placeholder():
     card = room_view["cards"][0]["cards"][0]
     assert card["icon"] == "mdi:help-circle-outline"
     assert card["name"] == "No entities"
+
+
+def test_overview_limit_global():
+    cfg = {
+        "overview_limit": 1,
+        "rooms": [
+            {
+                "name": "Room",
+                "cards": [
+                    {"type": "light", "entity": "light.a"},
+                    {"type": "light", "entity": "light.b"},
+                ],
+            }
+        ],
+    }
+    dash = build_dashboard(cfg, "en")
+    inner = dash["views"][0]["cards"][0]["cards"][0]["cards"][1]
+    assert len(inner["cards"]) == 1
+
+
+def test_overview_limit_room_override():
+    cfg = {
+        "overview_limit": 1,
+        "rooms": [
+            {
+                "name": "Room",
+                "overview_limit": 2,
+                "cards": [
+                    {"type": "light", "entity": "light.a"},
+                    {"type": "light", "entity": "light.b"},
+                    {"type": "light", "entity": "light.c"},
+                ],
+            }
+        ],
+    }
+    dash = build_dashboard(cfg, "en")
+    inner = dash["views"][0]["cards"][0]["cards"][0]["cards"][1]
+    assert len(inner["cards"]) == 2


### PR DESCRIPTION
## Summary
- allow configuring how many devices are shown for each room on the overview
- expose new `overview_limit` option globally and per room
- document the option and update example config
- test global and per-room overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878aece9c588320a2a782d01af9ef2d