### PR TITLE
Add fallback view when no rooms

### DIFF
--- a/custom_components/smart_dashboard/dashboard.py
+++ b/custom_components/smart_dashboard/dashboard.py
@@ -536,6 +536,17 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
             "cards": cards,
         })
 
+    if not views:
+        views.append({
+            "title": asyncio.run(t("dashboard_title", lang, "Smart Dashboard")),
+            "cards": [
+                {
+                    "type": "markdown",
+                    "content": asyncio.run(t("no_devices_found", lang, "No devices found.")),
+                }
+            ],
+        })
+
     dashboard = {"views": views}
     dashboard["button_card_templates"] = {
         "device_tile": {

--- a/custom_components/smart_dashboard/translations/bg.json
+++ b/custom_components/smart_dashboard/translations/bg.json
@@ -23,5 +23,7 @@
       }
     }
   },
-  "no_entities": "Няма устройства"
+  "no_entities": "Няма устройства",
+  "dashboard_title": "Smart Dashboard",
+  "no_devices_found": "Няма открити устройства"
 }

--- a/custom_components/smart_dashboard/translations/en.json
+++ b/custom_components/smart_dashboard/translations/en.json
@@ -23,5 +23,7 @@
       }
     }
   },
-  "no_entities": "No entities"
+  "no_entities": "No entities",
+  "dashboard_title": "Smart Dashboard",
+  "no_devices_found": "No devices found."
 }

--- a/custom_components/smart_dashboard/translations/es.json
+++ b/custom_components/smart_dashboard/translations/es.json
@@ -23,5 +23,7 @@
       }
     }
   },
-  "no_entities": "Sin entidades"
+  "no_entities": "Sin entidades",
+  "dashboard_title": "Smart Dashboard",
+  "no_devices_found": "No se encontraron dispositivos"
 }

--- a/custom_components/smart_dashboard/translations/fr.json
+++ b/custom_components/smart_dashboard/translations/fr.json
@@ -23,5 +23,7 @@
       }
     }
   },
-  "no_entities": "Aucune entité"
+  "no_entities": "Aucune entité",
+  "dashboard_title": "Smart Dashboard",
+  "no_devices_found": "Aucun appareil trouvé"
 }

--- a/custom_components/smart_dashboard/translations/ru.json
+++ b/custom_components/smart_dashboard/translations/ru.json
@@ -23,5 +23,7 @@
       }
     }
   },
-  "no_entities": "Нет сущностей"
+  "no_entities": "Нет сущностей",
+  "dashboard_title": "Smart Dashboard",
+  "no_devices_found": "Устройства не найдены"
 }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -96,3 +96,12 @@ def test_overview_limit_room_override():
     dash = build_dashboard(cfg, "en")
     inner = dash["views"][0]["cards"][0]["cards"][0]["cards"][1]
     assert len(inner["cards"]) == 2
+
+
+def test_fallback_view_when_empty():
+    cfg = {"rooms": []}
+    dash = build_dashboard(cfg, "en")
+    assert dash["views"][0]["title"] == "Smart Dashboard"
+    card = dash["views"][0]["cards"][0]
+    assert card["type"] == "markdown"
+    assert card["content"] == "No devices found."


### PR DESCRIPTION
## Summary
- provide fallback Lovelace view when no rooms are found
- localize fallback strings in all languages
- test fallback dashboard view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b4cda9d88320832db75582e8cd00