### PR TITLE
Document and add button-card resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ The easiest way to install is through HACS:
 4. Restart Home Assistant. This generates `smart_dashboard.yaml` and `dashboards/smart_dashboard.yaml`.
    The integration files live under `custom_components/smart_dashboard` in your configuration directory.
 5. The integration provides a `config_flow` declared in `manifest.json`, so it shows up automatically in the **Add Integration** dialog.
+6. Install the [Button Card](https://github.com/custom-cards/button-card) custom card in HACS and add the resource:
+
+   ```yaml
+   url: /hacsfiles/button-card/button-card.js
+   type: module
+   ```
+
+   Without this card the generated dashboard will not display device tiles correctly.
 
 See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for more details.
 

--- a/custom_components/smart_dashboard/generator.py
+++ b/custom_components/smart_dashboard/generator.py
@@ -259,8 +259,13 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
         dashboard["header"] = config["header"]
     if "sidebar" in config:
         dashboard["sidebar"] = config["sidebar"]
-    if "resources" in config:
-        dashboard["resources"] = config["resources"]
+
+    resources = list(config.get("resources", []))
+    urls = {res.get("url") for res in resources if isinstance(res, dict)}
+    if "/hacsfiles/button-card/button-card.js" not in urls:
+        resources.append({"url": "/hacsfiles/button-card/button-card.js", "type": "module"})
+    if resources:
+        dashboard["resources"] = resources
     return dashboard
 
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,6 +9,14 @@ Follow these steps to install the Smart Dashboard custom integration into Home A
    Choose **Smart Dashboard** to create the configuration entry.
 4. Restart Home Assistant to activate the integration.
    Since `manifest.json` enables a `config_flow`, Smart Dashboard appears automatically in the **Add Integration** list.
+5. Install the [Button Card](https://github.com/custom-cards/button-card) custom card in HACS and add the resource entry:
+
+   ```yaml
+   url: /hacsfiles/button-card/button-card.js
+   type: module
+   ```
+
+   This resource is required for the dashboard tiles to render correctly.
 
 ## Generate Your First Dashboard
 1. The first start creates `smart_dashboard.yaml` and `dashboards/smart_dashboard.yaml` automatically.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -43,6 +43,12 @@ def test_resources_included():
     }
     dash = build_dashboard(cfg, "en")
     assert dash["resources"][0]["url"] == "/local/test.js"
+    assert any(r.get("url") == "/hacsfiles/button-card/button-card.js" for r in dash["resources"])
+
+
+def test_button_card_resource_added():
+    dash = build_dashboard({"rooms": []}, "en")
+    assert any(r.get("url") == "/hacsfiles/button-card/button-card.js" for r in dash.get("resources", []))
 
 def test_dwains_plugin_resources():
     from custom_components.smart_dashboard.plugins.dwains_style import process_config


### PR DESCRIPTION
## Summary
- mention the button-card requirement in the README and installation docs
- automatically insert button-card.js as a Lovelace resource
- test default resource inclusion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bad38a3883208fc70b740fe68fd5