### PR TITLE
Add per-room grid column setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ module that draws a live clock in the header so the dashboard feels closer to
 Dwains Dashboard. The script is served from `/local/dwains_style.js` and is
 added automatically to the Lovelace `resources` section.
 
-Rooms are displayed using the Lovelace grid card with two columns. Individual
-devices appear as button-card tiles that feature a subtle background and rounded
-corners to better match the Dwains Dashboard style.
+Rooms are displayed using the Lovelace grid card with two columns by default.
+You can change the number of columns for each room using the ``columns``
+option. Individual devices appear as button-card tiles that feature a subtle
+background and rounded corners to better match the Dwains Dashboard style.
 
 `lovelace_cards_loader` can import existing Lovelace views by talking to the
 Home Assistant API. Enable it by setting `load_lovelace_cards: true` in your

--- a/custom_components/smart_dashboard/const.py
+++ b/custom_components/smart_dashboard/const.py
@@ -2,3 +2,4 @@ DOMAIN = "smart_dashboard"
 DASHBOARD_DIR = "dashboards"
 DASHBOARD_FILE = "smart_dashboard.yaml"
 DEFAULT_OVERVIEW_LIMIT = 4
+DEFAULT_GRID_COLUMNS = 2

--- a/custom_components/smart_dashboard/generator.py
+++ b/custom_components/smart_dashboard/generator.py
@@ -12,7 +12,7 @@ import yaml
 import voluptuous as vol
 from homeassistant.core import HomeAssistant
 
-from .const import DEFAULT_OVERVIEW_LIMIT
+from .const import DEFAULT_OVERVIEW_LIMIT, DEFAULT_GRID_COLUMNS
 from .plugins import load_plugins, run_plugins
 from .schema import CONFIG_SCHEMA
 from .templates import (
@@ -164,7 +164,7 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
             stack["cards"].append(
                 {
                     "type": "grid",
-                    "columns": 2,
+                    "columns": int(room.get("columns", DEFAULT_GRID_COLUMNS)),
                     "square": False,
                     "cards": tile_cards,
                 }
@@ -225,7 +225,7 @@ def build_dashboard(config: Dict[str, Any], lang: str) -> Dict[str, Any]:
             cards = [
                 {
                     "type": "grid",
-                    "columns": 2,
+                    "columns": int(room.get("columns", DEFAULT_GRID_COLUMNS)),
                     "square": False,
                     "cards": cards,
                 }

--- a/custom_components/smart_dashboard/schema.py
+++ b/custom_components/smart_dashboard/schema.py
@@ -1,5 +1,5 @@
 import voluptuous as vol
-from .const import DEFAULT_OVERVIEW_LIMIT
+from .const import DEFAULT_OVERVIEW_LIMIT, DEFAULT_GRID_COLUMNS
 
 # Card schema allows arbitrary keys so users can pass any card options
 CARD_SCHEMA = vol.Schema(
@@ -12,6 +12,9 @@ ROOM_SCHEMA = vol.Schema(
         vol.Optional("icon"): str,
         vol.Optional("order"): vol.Coerce(int),
         vol.Optional("layout"): vol.In(["horizontal", "vertical"]),
+        vol.Optional("columns", default=DEFAULT_GRID_COLUMNS): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
+        ),
         vol.Optional("overview_limit"): vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional("cards", default=[]): [CARD_SCHEMA],
         vol.Optional("conditions"): [str],

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -105,3 +105,23 @@ def test_fallback_view_when_empty():
     card = dash["views"][0]["cards"][0]
     assert card["type"] == "markdown"
     assert card["content"] == "No devices found."
+
+
+def test_room_columns_override():
+    cfg = {
+        "rooms": [
+            {
+                "name": "Room",
+                "columns": 3,
+                "cards": [{"type": "light", "entity": "light.l1"}],
+            }
+        ]
+    }
+    dash = build_dashboard(cfg, "en")
+    # Grid in the overview view uses the same column count
+    inner = dash["views"][0]["cards"][0]["cards"][0]["cards"][1]
+    assert inner["columns"] == 3
+    # Room view grid also respects the columns option
+    room_view = dash["views"][2]
+    grid = room_view["cards"][0]
+    assert grid["columns"] == 3


### PR DESCRIPTION
## Summary
- add `DEFAULT_GRID_COLUMNS` constant
- allow configuring `columns` for each room
- respect `columns` when building room grids
- document grid column option
- test per-room `columns`

## Testing
- `pip install pyyaml jinja2 requests voluptuous pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bc7d39808320af98676af3a86a5f