### PR TITLE
Implement dashboard generation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ python3 auto_update.py /path/to/your/homeassistant
 3. Reload Lovelace or restart Home Assistant again to see the new dashboard.
 4. You can edit `smart_dashboard.yaml` at any time to customise the layout,
    select a theme and run the generator manually if you wish.
+5. Call the `smart_dashboard.generate` service to rebuild the dashboard
+   without restarting Home Assistant.
 
 ## Requirements
 

--- a/custom_components/smart_dashboard/__init__.py
+++ b/custom_components/smart_dashboard/__init__.py
@@ -94,12 +94,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Smart Dashboard from a config entry."""
     await _generate_dashboard_files(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = True
+
+    if not hass.services.has_service(DOMAIN, "generate"):
+        async def handle_generate(call) -> None:
+            await _generate_dashboard_files(hass)
+
+        hass.services.async_register(DOMAIN, "generate", handle_generate)
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    if not hass.data.get(DOMAIN):
+        hass.services.async_remove(DOMAIN, "generate")
     return True
 
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -30,9 +30,11 @@ Follow these steps to install the Smart Dashboard custom integration into Home A
 4. To regenerate manually, run:
 
    ```bash
- python3 custom_components/smart_dashboard/dashboard.py smart_dashboard.yaml \
+  python3 custom_components/smart_dashboard/dashboard.py smart_dashboard.yaml \
       --output dashboards/smart_dashboard.yaml
   ```
+   Or call the `smart_dashboard.generate` service in Home Assistant to
+   rebuild the dashboard without restarting.
 
 You can also define a Lovelace theme by adding `theme: <name>` to
 `smart_dashboard.yaml`.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,59 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide dummy Home Assistant modules for import
+dummy = types.ModuleType("dummy")
+sys.modules.setdefault("homeassistant", dummy)
+core_mod = types.ModuleType("core")
+core_mod.HomeAssistant = object
+sys.modules.setdefault("homeassistant.core", core_mod)
+sys.modules.setdefault("homeassistant.helpers", types.ModuleType("helpers"))
+helpers_mod = sys.modules["homeassistant.helpers"]
+helpers_mod.area_registry = types.ModuleType("area_registry")
+helpers_mod.device_registry = types.ModuleType("device_registry")
+helpers_mod.entity_registry = types.ModuleType("entity_registry")
+sys.modules.setdefault("homeassistant.helpers.area_registry", helpers_mod.area_registry)
+sys.modules.setdefault("homeassistant.helpers.device_registry", helpers_mod.device_registry)
+sys.modules.setdefault("homeassistant.helpers.entity_registry", helpers_mod.entity_registry)
+sys.modules.setdefault("homeassistant.config_entries", types.ModuleType("config_entries"))
+sys.modules["homeassistant.config_entries"].ConfigEntry = object
+
+from custom_components import smart_dashboard as sd
+import asyncio
+
+class DummyServices:
+    def __init__(self):
+        self._registry = {}
+    def has_service(self, domain, service):
+        return (domain, service) in self._registry
+    def async_register(self, domain, service, func):
+        self._registry[(domain, service)] = func
+    def async_remove(self, domain, service):
+        self._registry.pop((domain, service), None)
+
+class DummyHass:
+    def __init__(self):
+        self.services = DummyServices()
+        self.data = {}
+
+def test_generate_service(monkeypatch):
+    hass = DummyHass()
+    entry = types.SimpleNamespace(entry_id="1")
+    called = {"count": 0}
+
+    async def fake_gen(h):
+        called["count"] += 1
+
+    monkeypatch.setattr(sd, "_generate_dashboard_files", fake_gen)
+
+    asyncio.run(sd.async_setup_entry(hass, entry))
+    assert hass.services.has_service(sd.DOMAIN, "generate")
+    handler = hass.services._registry[(sd.DOMAIN, "generate")]
+    asyncio.run(handler(None))
+    assert called["count"] == 2
+
+    asyncio.run(sd.async_unload_entry(hass, entry))
+    assert not hass.services.has_service(sd.DOMAIN, "generate")


### PR DESCRIPTION
## Summary
- expose `smart_dashboard.generate` service to rebuild the dashboard on demand
- document new service in README and installation guide
- add tests for the service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bdafd0f08320bc3721d62030885a