### PR TITLE
Fix missing sys import

### DIFF
--- a/custom_components/smart_dashboard/generator.py
+++ b/custom_components/smart_dashboard/generator.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 


### PR DESCRIPTION
## Summary
- add `sys` import to generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c9fb6ef883208c6fff6e090fae8e