### PR TITLE
Fix auto update repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Smart Dashboard is a customizable dashboard add-on for Home Assistant. It allows
 ## Installation
 
 The easiest way to install is through HACS:
-1. Add `https://github.com/user/Smart-Dashboard` as a custom repository of type "integration" in HACS.
+1. Add `https://github.com/MarkiZdeGenerAt/Smart-Dashboard` as a custom repository of type "integration" in HACS.
 2. Search for **Smart Dashboard** and install it.
 3. In Home Assistant open **Settings → Devices & Services** and click **Add Integration**.
    Select **Smart Dashboard** to create the configuration entry.

--- a/auto_update.py
+++ b/auto_update.py
@@ -15,7 +15,7 @@ from typing import Tuple
 
 import requests
 
-REPO_URL = "https://github.com/user/Smart-Dashboard"
+REPO_URL = "https://github.com/MarkiZdeGenerAt/Smart-Dashboard"
 ARCHIVE_URL = f"{REPO_URL}/archive/refs/heads/main.tar.gz"
 MANIFEST_URL = (
     f"{REPO_URL}/raw/main/custom_components/smart_dashboard/manifest.json"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,7 +3,7 @@
 Follow these steps to install the Smart Dashboard custom integration into Home Assistant.
 
 ## Install with HACS
-1. In HACS, add `https://github.com/user/Smart-Dashboard` as a custom repository of type "integration".
+1. In HACS, add `https://github.com/MarkiZdeGenerAt/Smart-Dashboard` as a custom repository of type "integration".
 2. Search for **Smart Dashboard** and install it.
 3. Open **Settings → Devices & Services** in Home Assistant and click **Add Integration**.
    Choose **Smart Dashboard** to create the configuration entry.

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 # Update script for the Smart Dashboard custom integration.
 set -euo pipefail
 
-REPO_URL="https://github.com/user/Smart-Dashboard"
+REPO_URL="https://github.com/MarkiZdeGenerAt/Smart-Dashboard"
 ARCHIVE_URL="$REPO_URL/archive/refs/heads/main.tar.gz"
 
 TARGET_DIR="${1:-$HOME/.homeassistant}"


### PR DESCRIPTION
## Summary
- point auto updater to the real GitHub repo
- update update script and docs with the correct repository URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878caa49ab0832092b963c86b455e06