### PR TITLE
Add switch and cover tile support

### DIFF
--- a/custom_components/smart_dashboard/auto_discovery.py
+++ b/custom_components/smart_dashboard/auto_discovery.py
@@ -147,10 +147,10 @@ def discover_devices(hass_url: str, token: str, lang: str) -> List[Dict[str, Any
         domain = entity_id.split(".")[0]
         card_type = {
             "light": "light",
-            "switch": "entity",
+            "switch": "light",
             "climate": "thermostat",
             "sensor": "sensor",
-            "cover": "entity",
+            "cover": "cover",
             "media_player": "media-control",
             "binary_sensor": "sensor",
         }.get(domain, "entity")
@@ -201,10 +201,10 @@ async def async_discover_devices_internal(
         domain = entity_id.split(".")[0]
         card_type = {
             "light": "light",
-            "switch": "entity",
+            "switch": "light",
             "climate": "thermostat",
             "sensor": "sensor",
-            "cover": "entity",
+            "cover": "cover",
             "media_player": "media-control",
             "binary_sensor": "sensor",
         }.get(domain, "entity")

--- a/custom_components/smart_dashboard/templates.py
+++ b/custom_components/smart_dashboard/templates.py
@@ -22,7 +22,9 @@ views:
 
 DEVICE_TEMPLATE_MAP = {
     "light": "light_tile",
+    "switch": "switch_tile",
     "climate": "climate_tile",
+    "cover": "cover_tile",
     "media_player": "media_tile",
     "sensor": "sensor_tile",
     "binary_sensor": "sensor_tile",
@@ -43,6 +45,8 @@ BUTTON_CARD_TEMPLATES: Dict[str, Dict[str, Any]] = {
         },
     },
     "light_tile": {"template": "device_tile", "tap_action": {"action": "toggle"}},
+    "switch_tile": {"template": "device_tile", "tap_action": {"action": "toggle"}},
+    "cover_tile": {"template": "device_tile", "tap_action": {"action": "toggle"}},
     "climate_tile": {"template": "device_tile"},
     "sensor_tile": {"template": "device_tile"},
     "media_tile": {"template": "device_tile"},

--- a/tests/test_card_type_fallback.py
+++ b/tests/test_card_type_fallback.py
@@ -34,8 +34,8 @@ class FakeResp:
 
 def test_unknown_types_use_entity(monkeypatch):
     states = [
-        {"entity_id": "switch.a"},
-        {"entity_id": "cover.b"},
+        {"entity_id": "vacuum.a"},
+        {"entity_id": "device_tracker.b"},
     ]
 
     def fake_get(url, headers=None, timeout=10):


### PR DESCRIPTION
## Summary
- show switch and cover entities as tiles
- map switch to light-style cards and add generic fallbacks for switch/cover
- adjust fallback tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878cfae177883208dc05be07eaeebb4