### PR TITLE
Add services.yaml for Smart Dashboard

### DIFF
--- a/custom_components/smart_dashboard/services.yaml
+++ b/custom_components/smart_dashboard/services.yaml
@@ -1,0 +1,5 @@
+# Service descriptions for Smart Dashboard integration
+generate:
+  name: Generate Dashboard
+  description: Rebuild the Smart Dashboard files based on the current configuration.
+


### PR DESCRIPTION
## Summary
- include services.yaml so Home Assistant finds service descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e34260ac83208d01ca8cf786918c